### PR TITLE
Google Photos link fix

### DIFF
--- a/meetups/hyderabad/01-assemble/README.md
+++ b/meetups/hyderabad/01-assemble/README.md
@@ -31,4 +31,4 @@ organizers:
 
 <EventPage />
 ## Google Photos Album 
-[https://photos.app.goo.gl/BU6QXzECrQBTG2dB9](https://photos.app.goo.gl/BU6QXzECrQBTG2dB9)
+https://photos.app.goo.gl/BU6QXzECrQBTG2dB9

--- a/meetups/hyderabad/02-jingle-bells/README.md
+++ b/meetups/hyderabad/02-jingle-bells/README.md
@@ -41,5 +41,4 @@ organizers:
 
 <EventPage />
 ## Google Photos Album
-https://photos.app.goo.gl/BU6QXzECrQBTG2dB9
-
+https://photos.app.goo.gl/dKY5yXg9URmKt1Ko6

--- a/meetups/hyderabad/02-jingle-bells/README.md
+++ b/meetups/hyderabad/02-jingle-bells/README.md
@@ -40,5 +40,6 @@ organizers:
 ---
 
 <EventPage />
-## Google Photos Album 
-[https://photos.app.goo.gl/BU6QXzECrQBTG2dB9](https://photos.app.goo.gl/BU6QXzECrQBTG2dB9)
+## Google Photos Album
+https://photos.app.goo.gl/BU6QXzECrQBTG2dB9
+


### PR DESCRIPTION
The Google photos links open a wrong link due to markdown syntax error. Fixed it!